### PR TITLE
fix(gsea): clamp +Inf/-Inf ranks instead of dropping them

### DIFF
--- a/diffex/gsea.qmd
+++ b/diffex/gsea.qmd
@@ -152,10 +152,19 @@ prep <- prepare_ranks(rnk)
 species <- prep$species
 ranks   <- prep$ranks
 
-# --- Sanitize ranks: remove NA/NaN/Inf and unnamed or duplicated entries ---
+# --- Sanitize ranks: clamp +Inf/-Inf, remove NA/NaN and unnamed or duplicated
+# entries ---
 # Many GSEA implementations (fgsea/clusterProfiler) expect a named numeric vector
 # of finite values. If the .rnk file contained NA/NaN/Inf or duplicate names,
 # fgsea::preparePathwaysAndStats can error with "Not all stats values are finite numbers".
+#
+# +Inf/-Inf typically come from p-value underflow (p == 0) on very strongly DE
+# genes -- a real, extreme signal rather than bad data (see issue #39). Dropping
+# those genes would erase the most significant hits from the ranked list, so
+# instead each is clamped to 2x the most extreme finite value on its side. This
+# keeps it at the extreme end of the ranking -- where an Inf-ranked gene belongs
+# -- without distorting fgsea's rank-based enrichment statistic, which only
+# depends on rank order and relative magnitude.
 
 # Ensure it's numeric (preserve names)
 if (!is.numeric(ranks)) {
@@ -163,10 +172,29 @@ if (!is.numeric(ranks)) {
   names(ranks) <- names(prep$ranks)
 }
 
-# Remove NA / NaN / Inf values
-bad_vals <- !is.finite(ranks) | is.na(ranks)
+# Clamp +Inf/-Inf to 2x the most extreme finite value on their respective side
+inf_vals <- is.infinite(ranks)
+if (any(inf_vals)) {
+  finite_ranks <- ranks[is.finite(ranks)]
+  if (length(finite_ranks) == 0) {
+    stop("GSEA: all rank values are +Inf/-Inf -- no finite values to clamp against")
+  }
+  pos_replacement <- 2 * max(finite_ranks)
+  neg_replacement <- 2 * min(finite_ranks)
+  n_pos_inf <- sum(ranks == Inf, na.rm = TRUE)
+  n_neg_inf <- sum(ranks == -Inf, na.rm = TRUE)
+  ranks[ranks == Inf]  <- pos_replacement
+  ranks[ranks == -Inf] <- neg_replacement
+  message(
+    "GSEA: clamped ", n_pos_inf, " +Inf rank(s) to ", pos_replacement,
+    " and ", n_neg_inf, " -Inf rank(s) to ", neg_replacement
+  )
+}
+
+# Remove NA / NaN values (unlike Inf, these carry no rank signal to preserve)
+bad_vals <- is.na(ranks)
 if (any(bad_vals)) {
-  message("GSEA: removing ", sum(bad_vals), " non-finite or NA rank values")
+  message("GSEA: removing ", sum(bad_vals), " NA/NaN rank values")
   ranks <- ranks[!bad_vals]
 }
 


### PR DESCRIPTION
## Summary

Fixes #39 properly. `main`/v0.5.3+ already stops the `preparePathwaysAndStats()` crash by *dropping* any gene with a non-finite `gsea_rank_score`, but that silently removes the most significant genes from GSEA input — e.g. the `IFIT2` example in #39 (a real, strongly-induced ISG whose p-value underflowed to exactly 0) would just disappear from the ranked list instead of sitting at the extreme end where it belongs.

This PR replaces the drop with a clamp: each `+Inf`/`-Inf` rank score is replaced with `2 × max(finite)` / `2 × min(finite)` on its respective side, before the (unchanged) NA/NaN-drop and duplicate-collapse steps run. `fgsea`'s enrichment statistic only depends on rank order and relative magnitude, so this preserves the gene's extreme position without distorting the result — it just makes the already-most-extreme genes finite.

This mirrors a workaround the [HAROLD](https://github.com/dremellab/HAROLD) pipeline has been running as an external pre-processing step on `.rnk` files (`_sanitize_rnk.py`) before ever calling `diffex gsea`, moved into `diffex` itself so it applies regardless of caller.

## Change

`diffex/gsea.qmd`: in the rank-sanitization block (right after `prepare_ranks()`), split the single `bad_vals <- !is.finite(ranks) | is.na(ranks)` drop into two steps:
1. Clamp `is.infinite(ranks)` entries to `2 * max/min(finite ranks)`.
2. Drop only `is.na(ranks)` (NA/NaN) entries — these carry no rank signal to preserve, unlike Inf.

## Testing

⚠️ I don't have R/Quarto available in the environment I authored this in, so I could **not** actually render `gsea.qmd` end-to-end to confirm this. The logic mirrors HAROLD's `_sanitize_rnk.py`, which has been running the identical clamp calculation in production for a while, but please treat this as needing a real render/test pass (e.g. against one of the affected `.rnk` files from #39) before merging.

## Scope note

Only fixes the *code path*, not distribution — per #40, no image newer than `0.5.2` has been published to `ghcr.io/dremellab/diffex`, so this fix (like the v0.5.3 UpSetR fix) won't reach downstream pipelines until a new image is built and pushed.
